### PR TITLE
News articles link to different articles

### DIFF
--- a/Yale/YPNewsArticlesTableViewController.m
+++ b/Yale/YPNewsArticlesTableViewController.m
@@ -129,15 +129,15 @@
 
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-  [self performSegueWithIdentifier:@"showArticle" sender:nil];
+  [self performSegueWithIdentifier:@"showArticle" sender:indexPath];
 }
 
 
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(NSIndexPath *)indexPath
 {
   if ([segue.identifier isEqualToString:@"showArticle"]) {
     YPNewsEmbeddedViewController *articleVC = segue.destinationViewController;
-    NSDictionary *articleNode = self.articlesArray[[self.tableView indexPathForCell:sender].row][@"node"];
+    NSDictionary *articleNode = self.articlesArray[indexPath.row][@"node"];
     articleVC.url = articleNode[@"path"];
     articleVC.title = [NSString stringWithFormat:@"YaleNews | %@", [articleNode[@"title"] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
     


### PR DESCRIPTION
I found that clicking on news articles in a given section only loaded the first article in that section. For example, clicking **any** news article in "Business, Law, Society" category would always load "Exploring interfaith communities..." instead of the other articles.
I fixed this issue by making sure the information about which cell is selected gets passed on to prepareForSegue:sender:
Now the other articles can be loaded.
I found this bug after about a minute of clicking around. I can't imagine what other bugs I've been missing.