### PR TITLE
First cell of map search is initially visible

### DIFF
--- a/Yale/YPMapsViewController.m
+++ b/Yale/YPMapsViewController.m
@@ -57,6 +57,9 @@
   tableViewFrame.size.height = self.view.bounds.size.height - tableViewFrame.origin.y;
   self.tableView.frame = tableViewFrame;
   [super viewWillAppear:animated];
+  
+  //resetting this here makes it so the first cell in the table view is actually visible.
+  self.tableView.tableHeaderView = self.searchController.searchBar;
 }
 
 - (void)setupBuildings {


### PR DESCRIPTION
Bug existed where the first cell of the map search (Phelps Hall) was initially covered by the search bar. I fixed this by resetting the headerview of the table to be the search bar. I have no idea why this worked, but it did.